### PR TITLE
Adds quotes around the copyfiles source glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint": "jshint src",
     "build:css": "node-sass src/index.sass > dist/index.css --output-style compact",
     "build:js": "browserify src/app/app.module.js > dist/app.js",
-    "build:html": "copyfiles -u 1 src/**/*.html dist/",
+    "build:html": "copyfiles -u 1 \"src/**/*.html\" dist",
     "build:assets": "copyfiles -u 1 src/content/**/* dist/",
     "build:clean": "npm install rimraf && npm run clean && npm install && npm run build:js && npm run build:css && npm run build:html && npm run build:assets",
     "build": "npm run build:js && npm run build:css && npm run build:html && npm run build:assets",


### PR DESCRIPTION
See [this issue](https://github.com/calvinmetcalf/copyfiles/issues/10), the task wasn't working for me unless I added the quotes. 
